### PR TITLE
Update information on ME and CC command responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ RIG control commands for the Kenwood TM-V71 and TM-D710(G)
 
 Reverse engineered commands for the TM-V71 and TM-D710(G).
 
-Thanks to: LA8OKA, W6GPS, WM8S and Lars Kellogg-Stedman for helping.
+Thanks to: LA8OKA, W6GPS, WM8S and N1LKS for helping.
 
 Based on rev.11 02 april 2009
 

--- a/commands/CC.md
+++ b/commands/CC.md
@@ -11,8 +11,8 @@ Get:
 |p|function|
 |---|---|
 |1|[Band](/tables/band.md)
-|2|Frequency in Hz 10 digit. must be within selected band
-|3|[Step size](/tables/step_size.md)
+|2|RX frequency in Hz 10 digit. Must be within selected band
+|3|[RX step size](/tables/step_size.md)
 |4|[Shift direction](/tables/shift.md)
 |5|[Reverse](/tables/status.md)
 |6|[Tone status](/tables/status.md)
@@ -21,7 +21,7 @@ Get:
 |9|[Tone frequency](/tables/tone_ctcss.md)
 |10|[CTCSS frequency](/tables/tone_ctcss.md)
 |11|[DSC frequency](/tables/DCS.md)
-|12|Offset frequency in Hz 8 digit. must be within selected band
+|12|Offset frequency in Hz 8 digit. Must be within the selected band.
 |13|[Mode](/tables/mode.md)
-|14|TX frequency in Hz 10 digit. must be within selected band
-|15|Unknown
+|14|TX frequency in Hz 10 digit. Must be within selected band
+|15|[TX step size](/tables/step_size.md)

--- a/commands/ME.md
+++ b/commands/ME.md
@@ -8,14 +8,18 @@ Set the memory channel:
 Read the memory channel:
 
 	ME xxx
+
+Clear the memory channel:
+
+  ME xxx,
 	
 Returns: memory channel number (3 digit)
 
 |p|function|
 |---|---|
 |1|Memory channel number 3 digit
-|2|Frequency in Hz 10 digit. C clears the channel
-|3|[Step size](/tables/step_size.md)
+|2|RX frequency in Hz 10 digit. C clears the channel
+|3|[RX step size](/tables/step_size.md)
 |4|[Shift direction](/tables/shift.md)
 |5|[Reverse](/tables/status.md)
 |6|[Tone status](/tables/status.md)
@@ -26,8 +30,8 @@ Returns: memory channel number (3 digit)
 |11|[DCS frequency](/tables/DCS.md)
 |12|Offset frequency in Hz 8 digit
 |13|[Mode](/tables/mode.md)
-|14|Frequency in Hz 10 digit.
-|15|unknown need help on this
+|14|TX frequency in Hz 10 digit.
+|15|[TX step size](/tables/step_size.md)
 |16|[Lock out](/tables/status.md)
 
 # 800-1300MHz not possible to set


### PR DESCRIPTION
Looking at the dump generated by the "Export to HMK" feature in MCP,
the unknown field in the ME and CC responses is the TX step size.