### PR TITLE
Correction to Mode documentation.

### DIFF
--- a/tables/mode.md
+++ b/tables/mode.md
@@ -3,7 +3,5 @@
 | Code | Function |
 |------|----------|
 | 0    | FM       |
-| 1    | AM       |
-| 2    | NFM      |
-
-# needs opdate
+| 1    | NFM      |
+| 2    | AM       |


### PR DESCRIPTION
The [mode](https://github.com/LA3QMA/TM-V71_TM-D710-Kenwood/blob/master/tables/mode.md) documentation mistakenly says that 0 is FM, 1 is AM, and 2 is NFM.  The correct values follow,. as verified on my Kenwood THM-D710GA.

```
0 -- FM
1 -- NFM
2 -- AM
```
